### PR TITLE
Add ctest calls to windows_noetic_build.yml

### DIFF
--- a/.github/workflows/windows_noetic_build.yml
+++ b/.github/workflows/windows_noetic_build.yml
@@ -41,3 +41,7 @@ jobs:
         catkin_make_isolated --install --use-nmake --force-cmake --only-pkg-with-deps tesseract_python --cmake-args -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=C:/opt/ros/noetic/x64/python.exe -DPYTHON_LIBRARY=C:/opt/ros/noetic/x64/Lib/python38.lib -DINSTALL_OMPL=ON -DINSTALL_OMPL_TAG=master -DBUILD_IPOPT=OFF -DBUILD_SNOPT=OFF -DINSTALL_FCL=ON -DINSTALL_BULLET=ON
         call "D:\a\tesseract_python\tesseract_python\install_isolated\setup.bat"
         catkin_make_isolated --install --use-nmake --force-cmake --pkg tesseract_python --cmake-args -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=C:/opt/ros/noetic/x64/python.exe -DPYTHON_LIBRARY=C:/opt/ros/noetic/x64/Lib/python38.lib -DTESSERACT_ENABLE_TESTING=ON -DINSTALL_OMPL=ON -DINSTALL_OMPL_TAG=master -DBUILD_IPOPT=OFF -DBUILD_SNOPT=OFF -DINSTALL_FCL=ON -DINSTALL_BULLET=ON
+
+        install_isolated\setup.bat
+        set TESSERACT_SUPPORT_DIR=%cd%\install_isolated\share\tesseract_support
+        cmd /c "cd src\tesseract_python\tesseract_python && python -m pytest -s"


### PR DESCRIPTION
Explicitly call pytest in Windows in windows_noetic_build.yml

I remember there being a problem with pytest in ROS Windows that requires uninstalling a package. I may need to adjust this PR to fix the problem.