### PR TITLE
Fix viewer memory lifecycle

### DIFF
--- a/tesseract_viewer_python/examples/abb_irb2400_viewer.py
+++ b/tesseract_viewer_python/examples/abb_irb2400_viewer.py
@@ -89,7 +89,7 @@ planning_server.waitForAll()
 
 assert response.interface.isSuccessful()
 
-results = flatten(response.getResults().as_CompositeInstruction())
+results = flatten(response.problem.getResults().as_CompositeInstruction())
 
 viewer.update_trajectory(results)
 

--- a/tesseract_viewer_python/package.xml
+++ b/tesseract_viewer_python/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>tesseract_viewer_python</name>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
   <description>The tesseract_viewer_python package</description>
   <maintainer email="wason@wasontech.com">John Wason</maintainer>
   <license>Apache 2.0</license>

--- a/tesseract_viewer_python/tesseract_robotics_viewer/tesseract_viewer.py
+++ b/tesseract_viewer_python/tesseract_robotics_viewer/tesseract_viewer.py
@@ -158,7 +158,8 @@ class TesseractViewer():
         
         start_instruction_o = tesseract_trajectory[0]
         assert isMoveInstruction(start_instruction_o)
-        start_waypoint_o = start_instruction_o.as_MoveInstruction().getWaypoint()
+        start_waypoint_m = start_instruction_o.as_MoveInstruction()
+        start_waypoint_o = start_waypoint_m.getWaypoint()
         assert isStateWaypoint(start_waypoint_o)
         start_waypoint = start_waypoint_o.as_StateWaypoint()
 
@@ -171,7 +172,8 @@ class TesseractViewer():
         for i in range(len(tesseract_trajectory)):
             instr = tesseract_trajectory[i]
             assert isMoveInstruction(instr)
-            wp = instr.as_MoveInstruction().getWaypoint()
+            instr_m = instr.as_MoveInstruction()
+            wp = instr_m.getWaypoint()
             assert isStateWaypoint(wp)
             state_wp = wp.as_StateWaypoint()
             trajectory2.append(state_wp.position.flatten().tolist() + [state_wp.time])


### PR DESCRIPTION
tesseract_viewer_python was having an issue in tesseract_viewer.py with C++ objects being destroyed while still being referenced. This has been corrected. I minor bug in abb viewer example has also been fixed.