### PR TITLE
Add missing import to tesseract_env_to_gltf.py

### DIFF
--- a/tesseract_viewer_python/tesseract_robotics_viewer/tesseract_env_to_gltf.py
+++ b/tesseract_viewer_python/tesseract_robotics_viewer/tesseract_env_to_gltf.py
@@ -17,6 +17,7 @@
 
 import json
 import struct
+import cv2
 import numpy as np
 import math
 from tesseract_robotics import tesseract_geometry


### PR DESCRIPTION
Add a missing import of cv2 to the tesseract_env_to_gltf.py module. Without this import, tesseract_material_mesh_viewer example fails.