### PR TITLE
Build package with 0.2.0.post1 version

### DIFF
--- a/tesseract_python/cmake/setup.py.in
+++ b/tesseract_python/cmake/setup.py.in
@@ -1,6 +1,9 @@
 # Based on https://github.com/robotraconteur/robotraconteur/blob/master/RobotRaconteurPython/setup.py.in
 
 from setuptools import setup, Distribution, find_packages, Extension
+from pathlib import Path
+
+long_description = (Path("@CMAKE_SOURCE_DIR@/..") / 'README.md').read_text()
 
 # Suggested at https://stackoverflow.com/questions/24071491/how-can-i-make-a-python-wheel-from-an-existing-native-library
 class BinaryDistribution(Distribution):
@@ -21,13 +24,20 @@ setup(name='tesseract-robotics',
       description='Tesseract Python Library',
       author='John Wason',
       author_email='wason@wasontech.com',
-      url='http://robotraconteur.com/',
+      url='https://tesseract-robotics.github.io/tesseract_python/',
+      project_urls={
+        'Documentation': 'https://tesseract-robotics.github.io/tesseract_python/',
+        'Source': 'https://github.com/tesseract-robotics/tesseract_python',
+        'Tracker': 'https://github.com/tesseract-robotics/tesseract_python/issues',
+      },
+      
       packages=find_packages(include=['tesseract_robotics','tesseract_robotics.*']),
       package_data={'': ['*.pyd', '*.so', '*.dll']},
 	  distclass=BinaryDistribution,
 	  license='Apache-2.0',
 	  install_requires=['numpy'],
-	  long_description='Tesseract Robotics package for Python',
+	  long_description=long_description,
+    long_description_content_type='text/markdown',
       ext_modules=[
         Extension(
           name='tesseract_robotics.tesseract_common._tesseract_common',

--- a/tesseract_python/cmake/setup.py.in
+++ b/tesseract_python/cmake/setup.py.in
@@ -20,7 +20,7 @@ class build_ext(build_ext_orig):
       pass
 
 setup(name='tesseract-robotics',
-      version='@tesseract_python_version@',
+      version='@tesseract_python_version@.post1',
       description='Tesseract Python Library',
       author='John Wason',
       author_email='wason@wasontech.com',


### PR DESCRIPTION
This will use an action to build with version 0.2.0.post1 so it can be uploaded to PyPi to replace the version 0.2.0 package. No other changes have been made. This PR will be closed without merging.