### PR TITLE
Extend ProfileDictionary in Python

### DIFF
--- a/tesseract_python/src/tesseract_robotics/tesseract_command_language/profile_dictionary.py
+++ b/tesseract_python/src/tesseract_robotics/tesseract_command_language/profile_dictionary.py
@@ -1,0 +1,45 @@
+from tesseract_robotics import tesseract_command_language
+from tesseract_robotics.tesseract_motion_planners_trajopt import (
+    ProfileDictionary_addProfile_TrajOptCompositeProfile,
+    ProfileDictionary_addProfile_TrajOptPlanProfile,
+    ProfileDictionary_addProfile_TrajOptSolverProfile,
+    ProfileDictionary_getProfile_TrajOptCompositeProfile,
+    ProfileDictionary_getProfile_TrajOptPlanProfile,
+    ProfileDictionary_getProfile_TrajOptSolverProfile,
+    ProfileDictionary_hasProfile_TrajOptCompositeProfile,
+    ProfileDictionary_hasProfile_TrajOptPlanProfile,
+    ProfileDictionary_hasProfile_TrajOptSolverProfile,
+    TrajOptCompositeProfile,
+    TrajOptPlanProfile,
+    TrajOptSolverProfile,
+)
+
+
+class ProfileDictionary(tesseract_command_language.ProfileDictionary):
+    def __init__(self):
+        super().__init__()
+
+    def add_profile(self, ns: str, profile_name: str, profile):
+        if issubclass(profile.__class__, TrajOptCompositeProfile):
+            ProfileDictionary_addProfile_TrajOptCompositeProfile(
+                profile_dictionary=self, ns=ns, profile_name=profile_name, profile=profile
+            )
+
+        elif issubclass(profile.__class__, TrajOptPlanProfile):
+            ProfileDictionary_addProfile_TrajOptPlanProfile(
+                profile_dictionary=self, ns=ns, profile_name=profile_name, profile=profile
+            )
+
+        elif issubclass(profile.__class__, TrajOptSolverProfile):
+            ProfileDictionary_addProfile_TrajOptSolverProfile(
+                profile_dictionary=self, ns=ns, profile_name=profile_name, profile=profile
+            )
+
+        else:
+            raise NotImplementedError()
+
+    def get_profile(self, ns: str, profile_name: str):
+        raise NotImplementedError()
+
+    def has_profile(self, ns: str, profile_name: str):
+        raise NotImplementedError()


### PR DESCRIPTION
In #51 I saw a comment in the code of adding a `add_profile` function for the `ProfileDictionary` class. 

I have created a small example that could do that using the available wrapper functions and extending the `ProfileDictionary` class in Python. I assumed for this example it is possible to extend a .so library with Python code.

I am curious if this approach of extending some of the wrapped classes in Python to mimic the C++ functionality is something you would consider for this repository or if you would rather update the SWIG configuration to achieve the same/similar. 

The example as is would likely cause some name clash, but I assume that the C++ `ProfileDictionary` could be placed in a separate namespace or be renamed in the binding to do effectively the same thing.  
 