### PR TITLE
Fix: Ensure the resource is not None before we call getUrl

### DIFF
--- a/tesseract_viewer_python/tesseract_robotics_viewer/tesseract_env_to_gltf.py
+++ b/tesseract_viewer_python/tesseract_robotics_viewer/tesseract_env_to_gltf.py
@@ -219,7 +219,7 @@ def _convert_mesh(gltf_dict, gltf_buf_io, visual_node, visual_name, mesh):
 
     visual_node["scale"] = list(mesh.getScale().flatten())
 
-    if not mesh.getResource().getUrl().lower().endswith('.stl'):
+    if mesh.getResource() is not None and not mesh.getResource().getUrl().lower().endswith('.stl'):
         mesh_material = mesh.getMaterial()
         if mesh_material is not None:
         


### PR DESCRIPTION
The resource can potentially be None because of this piece of code in `tesseract`:

https://github.com/tesseract-robotics/tesseract/blob/821da48bf9b9a16a4cfeeffb39631b9797bbd6d8/tesseract_geometry/include/tesseract_geometry/mesh_parser.h#L403

```cpp
  return createMeshFromAsset<T>(scene, scale, nullptr, normals, vertex_colors, material_and_texture);
```

It will raise error `'NoneType' object has no attribute 'getUrl'` and break the program.